### PR TITLE
fix(other): wrongful relative includes in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src", "../utopia-ui/src/Components/Templates/CardPage.tsx", "../../workspace/utopia-ui/src/Components/Templates/MoonCalendar.tsx", "../../workspace/utopia-ui/src/Components/Templates/ItemIndexPage.tsx"],
+  "include": ["src"], 
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

For some reason specific Components were included in the tsconfig.json with a relative path. This should have caused problems for anyone who has not checked out `utopia-ui` in the coresponding location. This was discovered due to the fact that we cannot include components directly anymore since they include paths have project specific path aliases

Builds
![image](https://github.com/user-attachments/assets/8c0fb6eb-8274-49cf-b97a-abf597a14d38)

Works
![image](https://github.com/user-attachments/assets/fb290f4a-2e80-4747-87f6-766cddc7ee1c)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/utopia-os/utopia-ui/issues/39

### Todo
<!-- In case some parts are still missing, list them here. -->
- [ ] Investigate Commits in question - does everything work as expected?

Commits in question:
- https://github.com/utopia-os/utopia-map/commit/94965a161c7955096fe19286f3967dbcfe59d9d8#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0L22
- https://github.com/utopia-os/utopia-map/commit/e742dd20b683ae67512822dc476d70202da137ec#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0L22
