### PR TITLE
[NO-MERGE] fix(other): added missing dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "date-fns": "^3.3.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-leaflet-cluster": "^2.1.0",
         "react-rnd": "^10.4.1",
         "react-router-dom": "^6.23.0",
         "utopia-ui": "^3.0.19"
@@ -5885,6 +5886,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-leaflet-cluster/-/react-leaflet-cluster-2.1.0.tgz",
       "integrity": "sha512-16X7XQpRThQFC4PH4OpXHimGg19ouWmjxjtpxOeBKpvERSvIRqTx7fvhTwkEPNMFTQ8zTfddz6fRTUmUEQul7g==",
+      "license": "SEE LICENSE IN <LICENSE>",
       "dependencies": {
         "leaflet.markercluster": "^1.5.3"
       },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "date-fns": "^3.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-leaflet-cluster": "^2.1.0",
     "react-rnd": "^10.4.1",
     "react-router-dom": "^6.23.0",
     "utopia-ui": "^3.0.19"


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

fix(other): added missing dependency

`react-leaflet-cluster` is defined as external in `utopia-ui` and with the types pr https://github.com/utopia-os/utopia-ui/pull/52, I get runtime errors when I do not provide `react-leaflet-cluster`.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- there is an alternative PR solving this issue in a broader sense: https://github.com/utopia-os/utopia-ui/pull/53

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
