### PR TITLE
fix(other): polyfills text-encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-dom": "^18.2.0",
         "react-rnd": "^10.4.1",
         "react-router-dom": "^6.23.0",
+        "text-encoding-polyfill": "^0.6.7",
         "utopia-ui": "^3.0.19"
       },
       "devDependencies": {
@@ -6682,6 +6683,12 @@
       "version": "2.20.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/text-encoding-polyfill": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/text-encoding-polyfill/-/text-encoding-polyfill-0.6.7.tgz",
+      "integrity": "sha512-/DZ1XJqhbqRkCop6s9ZFu8JrFRwmVuHg4quIRm+ziFkR3N3ec6ck6yBvJ1GYeEQZhLVwRW0rZE+C3SSJpy0RTg==",
+      "license": "Unlicense"
     },
     "node_modules/text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-dom": "^18.2.0",
     "react-rnd": "^10.4.1",
     "react-router-dom": "^6.23.0",
+    "text-encoding-polyfill": "^0.6.7",
     "utopia-ui": "^3.0.19"
   },
   "devDependencies": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import 'text-encoding-polyfill'; // https://trycatchdebug.net/news/1129689/vite-build-error-textencoder
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 // vite.config.js
@@ -11,7 +12,7 @@ export default defineConfig({
   },
   plugins: [
     react()
-  ]
+  ],
 })
 
 {/**


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

polyfills text-encoding

This seems to be required by some packages now included into the rollup bundle (https://github.com/utopia-os/utopia-ui/pull/53). As of
https://trycatchdebug.net/news/1129689/vite-build-error-textencoder the polifill seems to be a good solution, removing errors from my build.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- is required for https://github.com/utopia-os/utopia-ui/pull/53

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
